### PR TITLE
Allow ordering when performing a FIND query

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ var data = {
         query: 'JOIN table_b on table_a.join_id = table_b.id',
     },
     selects: 'table_b.*',
+    orderBy: ['join_id'],
 };
 
 // Or find and return all data from `table_a`

--- a/lib/websqlClass.js
+++ b/lib/websqlClass.js
@@ -321,7 +321,13 @@
                                 this.orderBy = '';
                             }
                         } else {
-                            this.conditions += key + '="' + val + '"';
+                            this.conditions += key;
+
+                            if (typeof val === 'string' && val.toUpperCase().startsWith('IS ')) {
+                                this.conditions += ' ' + val;
+                            } else {
+                                this.conditions += ' = "' + val + '"';
+                            }
                         }
                     }
                 }

--- a/lib/websqlClass.js
+++ b/lib/websqlClass.js
@@ -333,6 +333,7 @@
                 }
 
                 if (data.selects) {
+                    data.selects = Array.isArray(data.selects) ? data.selects.join(', ') : data.selects;
                     this.query = 'SELECT ' + data.selects + ', ' + this.table + '.* ';
                 } else {
                     if (data.join) {
@@ -343,6 +344,7 @@
                 }
 
                 if (data.join) {
+                    data.join.query = Array.isArray(data.join.query) ? data.join.query.join(' ') : data.join.query;
                     this.conditions = data.join.query + ' ' + this.conditions;
                 }
 

--- a/lib/websqlClass.js
+++ b/lib/websqlClass.js
@@ -329,7 +329,11 @@
                 if (data.selects) {
                     this.query = 'SELECT ' + data.selects + ', ' + this.table + '.* ';
                 } else {
-                    this.query = 'SELECT * ';
+                    if (data.join) {
+                        this.query = 'SELECT *, ' + this.table + '.* ';
+                    } else {
+                        this.query = 'SELECT * ';
+                    }
                 }
 
                 if (data.join) {

--- a/lib/websqlClass.js
+++ b/lib/websqlClass.js
@@ -345,7 +345,7 @@
                         this.query += ' ';
                     }
 
-                    this.query += data.orderBy.join(' ');
+                    this.query += data.orderBy.join(', ');
                 }
 
                 this.queryValues = [];

--- a/lib/websqlClass.js
+++ b/lib/websqlClass.js
@@ -286,10 +286,9 @@
                 break;
             case 'find':
                 this.conditions = '';
+                this.orderBy    = '';
 
-                if (Object.keys(data.data).length === 0) {
-                    this.conditions = '';
-                } else {
+                if (Object.keys(data.data).length > 0) {
                     for (key in data.data) {
                         var val = data.data[key];
 
@@ -318,6 +317,8 @@
 
                             if (isValNumber) {
                                 this.conditions += this.orderBy;
+                            } else {
+                                this.orderBy = '';
                             }
                         } else {
                             this.conditions += key + '="' + val + '"';
@@ -336,6 +337,16 @@
                 }
 
                 this.query += 'FROM ' + this.table + ' ' + this.conditions;
+
+                if (data.orderBy) {
+                    if (this.orderBy.length === 0) {
+                        this.query += ' ORDER BY ';
+                    } else {
+                        this.query += ' ';
+                    }
+
+                    this.query += data.orderBy.join(' ');
+                }
 
                 this.queryValues = [];
                 this.queryType = 'find';


### PR DESCRIPTION
- Allow ordering when performing a FIND query
- Ensure when using a join within a FIND query that any column from the parent table is not overridden if it also exists in the join table
- Support using `IS` within conditional data
- Support handling an array of `selects` or `join.query` when performing a FIND query